### PR TITLE
Dynamic Port Support

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,4 +1,4 @@
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:59449/';
+const API_URL = process.env.REACT_APP_API_URL || `http://localhost:${window.location.port}/`;
 const RUNNER_URL = process.env.REACT_APP_RUNNER_URL || 'https://chainshot-relayer.herokuapp.com/run/';
 const SOLC_COMPILER_URL = process.env.REACT_APP_SOLC_COMPILER_URL || 'https://www.chainshot.com/server/solc';
 const VPYER_COMPILER_URL = process.env.REACT_APP_VPYER_COMPILER_URL || 'https://vyper-compiler.herokuapp.com/compile/';

--- a/docs/builder_structure.rst
+++ b/docs/builder_structure.rst
@@ -71,8 +71,13 @@ Some of the override-able settings include:
 ====================  ===========================================================================
 Field                 Description
 ====================  ===========================================================================
-REACT_APP_API_URL     The API URL for the builder server (useful if changing builder server PORT)
+REACT_APP_API_URL     The API URL for the builder server
 ====================  ===========================================================================
+
+.. note::
+  The client will fallback to the :code:`window.location.port` unless given an explicit
+  API URL. This is done so that the client can bind to dynamic ports from the CLI after
+  it's been packaged up in a release build.
 
 Server
 ======

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -10,7 +10,7 @@ const CONFIG_DIR = `${CONTENT_DIR}/config`;
 const PROJECTS_DIR = `${CONTENT_DIR}/projects`;
 const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
 const INITIAL_CODE_DIR = 'setup';
-const PORT = process.env.PORT || 59449;
+const PORT = process.env.PORT || 3030;
 const LOOKUP_KEY = '$$LOOKUP';
 const MODEL_DB = {
   CODE_FILES: 'codeFiles',


### PR DESCRIPTION
Allows for the server to be bound to whatever PORT is available, and the client will follow suit by default.