### PR TITLE
Readme Node Version Note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ chainshot-builder init
 This will spin up the IDE and get you started. To learn more about editing and committing
 to your new content repository check out the [Building New Content Docs](https://chainshotbuilder.readthedocs.io/en/latest/building_new_content.html#start-editing).
 
+**Note:** You'll want to have the **latest** version of Node installed to ensure
+builder compatibility. For switching between versions easily, we suggest you check
+out the [n](https://www.npmjs.com/package/n) package.
+
 ### App Preview
 
 ![Builder Preview](preview.png)

--- a/server/templates/README.md
+++ b/server/templates/README.md
@@ -17,6 +17,10 @@ chainshot-builder run
 Any modifications made in the IDE will be reflected in the file system immediately and can be
 committed up to your repository.
 
+**Note:** You'll want to have the **latest** version of Node installed to ensure
+builder compatibility. For switching between versions easily, we suggest you check
+out the [n](https://www.npmjs.com/package/n) package.
+
 ## Content Structure
 
 Content Repositories contain two folders, [projects and config](https://chainshotbuilder.readthedocs.io/en/latest/content.html#structure), which are used to track modifications to content and open up collaboration between many content creators.


### PR DESCRIPTION
To ensure compatibility with the Builder, content creators should be on the latest version of Node. This came up in issue #104 