### PR TITLE
Add Node 10.x with Crypto Packages 

### DIFF
--- a/client/src/components/ide/configuration/CodeStageConfig.jsx
+++ b/client/src/components/ide/configuration/CodeStageConfig.jsx
@@ -9,8 +9,12 @@ const TEST_FRAMEWORK_HINT = 'The framework used for test assertions';
 const languageVersionOptions = [
   { label: 'Solidity v0.4.19', value: '0.4.19' },
   { label: 'Vyper v0.1', value: '0.1.0b3' },
-  { label: 'Node 8.x', value: '8.x/babel' },
-  { label: 'Node 6.x', value: '6.x/babel' },
+  { label: 'Node 10.x', value: '10.x' },
+  { label: 'Node 10.x w/ Babel', value: '10.x/babel' },
+  { label: 'Node 8.x', value: '8.x' },
+  { label: 'Node 8.x w/ Babel', value: '8.x/babel' },
+  { label: 'Node 6.x', value: '6.x' },
+  { label: 'Node 6.x w/ Babel', value: '6.x/babel' },
 ]
 
 const frameworkOptions = [


### PR DESCRIPTION
Node 10.x has installed: 
```
    "chai": "^4.2.0",
    "crypto-js": "^3.1.9-1",
    "d3-random": "^1.1.2",
    "eth-crypto": "^1.3.2",
    "ethereumjs-util": "^6.0.0",
    "ethers": "^4.0.23",
    "faker": "^4.1.0",
    "lodash": "^4.17.11",
    "mocha": "^5.2.0",
    "seedrandom": "^2.4.4",
    "web3": "^1.0.0-beta.38",
    "web3-providers": "^1.0.0-beta.38",
    "zen-observable": "^0.8.13"
```